### PR TITLE
Changes for ImportDependency 0.3.4 and extended documentation

### DIFF
--- a/ImportDependency/ImportDependency/ImportDependency.psd1
+++ b/ImportDependency/ImportDependency/ImportDependency.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ImportDependency.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.3'
+ModuleVersion = '0.3.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -112,6 +112,10 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+0.3.4 Added more switches to get faster execution of Get-PSEnvironment
+      Added a synopsys to Get-PSEnvironment
+      Changed the approach to load the versions of PowerShellGet and PackageManagement
+      Loading the OS directly at the start of module import to determine if PATH needs to be extended
 0.3.3 Fixed a problem when VCRedist is not installed at all
 0.3.2 Added functionality to load global and local packages into Get-PSEnvironment
 0.3.1 Added check of vcredist, powershellget and packagemanagement version

--- a/ImportDependency/ImportDependency/ImportDependency.psm1
+++ b/ImportDependency/ImportDependency/ImportDependency.psm1
@@ -14,62 +14,94 @@ https://github.com/RamblingCookieMonster/PSStackExchange/blob/db1277453374cb1668
 
 
 #-----------------------------------------------
+# OS CHECK
+#-----------------------------------------------
+
+$preCheckisCore = ($PSVersionTable.Keys -contains "PSEdition") -and ($PSVersionTable.PSEdition -ne 'Desktop')
+
+# Check the operating system, if Core
+if ($preCheckisCore -eq $true) {
+    If ( $IsWindows -eq $true ) {
+        $preCheckOs = "Windows"
+    } elseif ( $IsLinux -eq $true ) {
+        $preCheckOs = "Linux"
+    } elseif ( $IsMacOS -eq $true ) {
+        $preCheckOs = "MacOS"
+    } else {
+        throw "Unknown operating system"
+    }
+} else {
+    # [System.Environment]::OSVersion.VersionString()
+    # [System.Environment]::Is64BitOperatingSystem
+    $preCheckOs = "Windows"
+}
+
+
+#-----------------------------------------------
 # ADD MODULE PATH, IF NOT PRESENT
 #-----------------------------------------------
 
-$modulePath = @( [System.Environment]::GetEnvironmentVariable("PSModulePath") -split ";" ) + @(
-    "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\WindowsPowerShell\Modules"
-    "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\WindowsPowerShell\Modules"
-    "$( [System.Environment]::GetEnvironmentVariable("USERPROFILE") )\Documents\WindowsPowerShell\Modules"
-    "$( [System.Environment]::GetEnvironmentVariable("windir") )\system32\WindowsPowerShell\v1.0\Modules"
-)
+If ( $preCheckOs -eq "Windows" ) {
 
-# Add the 64bit path, if present. In 32bit the ProgramFiles variables only returns the x86 path
-If ( [System.Environment]::GetEnvironmentVariables().keys -contains "ProgramW6432" ) {
-    $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\WindowsPowerShell\Modules"
-}
+    $modulePath = @( [System.Environment]::GetEnvironmentVariable("PSModulePath") -split ";" ) + @(
+        "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\WindowsPowerShell\Modules"
+        "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\WindowsPowerShell\Modules"
+        "$( [System.Environment]::GetEnvironmentVariable("USERPROFILE") )\Documents\WindowsPowerShell\Modules"
+        "$( [System.Environment]::GetEnvironmentVariable("windir") )\system32\WindowsPowerShell\v1.0\Modules"
+    )
 
-# Add pwsh core path
-If ( $Script:isCore -eq $true ) {
+    # Add the 64bit path, if present. In 32bit the ProgramFiles variables only returns the x86 path
     If ( [System.Environment]::GetEnvironmentVariables().keys -contains "ProgramW6432" ) {
-        $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\powershell\7\Modules"
+        $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\WindowsPowerShell\Modules"
     }
-    $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\powershell\7\Modules"
-    $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\powershell\7\Modules"
-}
 
-# Add all paths
-# Using $env:PSModulePath for only temporary override
-$Env:PSModulePath = @( $modulePath | Sort-Object -unique ) -join ";"
+    # Add pwsh core path
+    If ( $Script:isCore -eq $true ) {
+        If ( [System.Environment]::GetEnvironmentVariables().keys -contains "ProgramW6432" ) {
+            $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\powershell\7\Modules"
+        }
+        $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\powershell\7\Modules"
+        $modulePath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\powershell\7\Modules"
+    }
+
+    # Add all paths
+    # Using $env:PSModulePath for only temporary override
+    $Env:PSModulePath = @( $modulePath | Sort-Object -unique ) -join ";"
+
+}
 
 
 #-----------------------------------------------
 # ADD SCRIPT PATH, IF NOT PRESENT
 #-----------------------------------------------
 
-#$envVariables = [System.Environment]::GetEnvironmentVariables()
-$scriptPath = @( [System.Environment]::GetEnvironmentVariable("Path") -split ";" ) + @(
-    "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\WindowsPowerShell\Scripts"
-    "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\WindowsPowerShell\Scripts"
-    "$( [System.Environment]::GetEnvironmentVariable("USERPROFILE") )\Documents\WindowsPowerShell\Scripts"
-)
+If ( $preCheckOs -eq "Windows" ) {
 
-# Add the 64bit path, if present. In 32bit the ProgramFiles variables only returns the x86 path
-If ( [System.Environment]::GetEnvironmentVariables().keys -contains "ProgramW6432" ) {
-    $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\WindowsPowerShell\Scripts"
-}
+    #$envVariables = [System.Environment]::GetEnvironmentVariables()
+    $scriptPath = @( [System.Environment]::GetEnvironmentVariable("Path") -split ";" ) + @(
+        "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\WindowsPowerShell\Scripts"
+        "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\WindowsPowerShell\Scripts"
+        "$( [System.Environment]::GetEnvironmentVariable("USERPROFILE") )\Documents\WindowsPowerShell\Scripts"
+    )
 
-# Add pwsh core path
-If ( $Script:isCore -eq $true ) {
+    # Add the 64bit path, if present. In 32bit the ProgramFiles variables only returns the x86 path
     If ( [System.Environment]::GetEnvironmentVariables().keys -contains "ProgramW6432" ) {
-        $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\powershell\7\Scripts"
+        $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\WindowsPowerShell\Scripts"
     }
-    $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\powershell\7\Scripts"
-    $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\powershell\7\Scripts"
-}
 
-# Using $env:Path for only temporary override
-$Env:Path = @( $scriptPath | Sort-Object -unique ) -join ";"
+    # Add pwsh core path
+    If ( $Script:isCore -eq $true ) {
+        If ( [System.Environment]::GetEnvironmentVariables().keys -contains "ProgramW6432" ) {
+            $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramW6432") )\powershell\7\Scripts"
+        }
+        $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles") )\powershell\7\Scripts"
+        $scriptPath += "$( [System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)") )\powershell\7\Scripts"
+    }
+
+    # Using $env:Path for only temporary override
+    $Env:Path = @( $scriptPath | Sort-Object -unique ) -join ";"
+
+}
 
 
 #-----------------------------------------------
@@ -133,12 +165,14 @@ New-Variable -Name installedModules -Value $null -Scope Script -Force           
 New-Variable -Name backgroundJobs -Value $null -Scope Script -Force               # Hidden variable to store background jobs
 New-Variable -Name installedGlobalPackages -Value $null -Scope Script -Force               # Caches all installed NuGet Global Packages
 
-
+$Script:isCore = $preCheckisCore
+$Script:os = $preCheckOs
 $Script:psVersion = $PSVersionTable.PSVersion.ToString()
 $Script:psEdition = $PSVersionTable.PSEdition
 $Script:platform = $PSVersionTable.Platform
 $Script:is64BitOS = [System.Environment]::Is64BitOperatingSystem
 $Script:is64BitProcess = [System.Environment]::Is64BitProcess
+
 <#
 $Script:frameworkPreference = @(
 
@@ -160,25 +194,6 @@ $Script:frameworkPreference = @(
 
 )
 #>
-
-$Script:isCore = ($PSVersionTable.Keys -contains "PSEdition") -and ($PSVersionTable.PSEdition -ne 'Desktop')
-
-# Check the operating system, if Core
-if ($Script:isCore -eq $true) {
-    If ( $IsWindows -eq $true ) {
-        $Script:os = "Windows"
-    } elseif ( $IsLinux -eq $true ) {
-        $Script:os = "Linux"
-    } elseif ( $IsMacOS -eq $true ) {
-        $Script:os = "MacOS"
-    } else {
-        throw "Unknown operating system"
-    }
-} else {
-    # [System.Environment]::OSVersion.VersionString()
-    # [System.Environment]::Is64BitOperatingSystem
-    $Script:os = "Windows"
-}
 
 If ( $null -ne [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture ) {
 
@@ -318,6 +333,19 @@ if ($Script:os -eq "Windows") {
     $Script:isElevated = $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
 }
 
+# Check PowerShellGet and Packagemanagement
+Import-Module PowerShellGet -ErrorAction SilentlyContinue
+$modules = Get-Module
+
+# Check if PackageManagement and PowerShellGet are available
+$modules | where-object { $_.Name -eq "PackageManagement" } | ForEach-Object {
+    $Script:packageManagement = $_.Version.ToString()
+}
+$modules | where-object { $_.Name -eq "PowerShellGet" } | ForEach-Object {
+    $Script:powerShellGet = $_.Version.ToString()
+}
+
+# Add jobs to find out more about installed modules and packages in the background
 $Script:backgroundJobs = [System.Collections.ArrayList]@()
 [void]$Script:backgroundJobs.Add((
     Start-Job -ScriptBlock {

--- a/ImportDependency/ImportDependency/Private/Update-BackgroundJob.ps1
+++ b/ImportDependency/ImportDependency/Private/Update-BackgroundJob.ps1
@@ -28,14 +28,6 @@ function Update-BackgroundJob {
 
                     $Script:installedModules = $results
 
-                    # Check if PackageManagement and PowerShellGet are available
-                    $Script:installedModules | where-object { $_.Name -eq "PackageManagement" } | ForEach-Object {
-                        $Script:packageManagement = $_.Version.ToString()
-                    }
-                    $Script:installedModules | where-object { $_.Name -eq "PowerShellGet" } | ForEach-Object {
-                        $Script:powerShellGet = $_.Version.ToString()
-                    }
-
                 }
 
                 "InstalledGlobalPackages" {

--- a/ImportDependency/README.md
+++ b/ImportDependency/README.md
@@ -145,6 +145,80 @@ Install-Dependencies -LocalPackage MailKit -verbose
 Import-Dependency -LoadWholePackageFolder -LocalPackageFolder "./lib" -verbose
 ```
 
+## Check the current PowerShell environment
+
+Use this to get a good overview of the current environment. This is useful information for loading dependencies or to operate on different operating systems etc.
+
+```PowerShell
+Get-PSEnvironment
+
+Name                           Value
+----                           -----
+PSVersion                      5.1.26100.6584
+PSEdition                      Desktop
+OS                             Windows
+IsCore                         False
+Architecture                   ARM64
+CurrentRuntime                 net4.0
+Is64BitOS                      True
+Is64BitProcess                 True
+ExecutingUser                  FLOPRO11\flo
+IsElevated                     False
+RuntimePreference              win-arm64, win-arm, win-x64, win-x86
+FrameworkPreference            net48, net47, net462, net461, net45, net40, netstandard2.0, netstandard1.5, netstandard1....
+PackageManagement              1.4.8.1
+PowerShellGet                  2.2.5
+VcRedist                       @{installed=True; is64bit=True; versions=System.Collections.Hashtable}
+BackgroundCheckCompleted       True
+InstalledModules               {@{Name=PackageManagement; Version=1.4.8.1; Type=Module; Description=PackageManagement (a...
+InstalledGlobalPackages        {Microsoft.PackageManagement.Packaging.SoftwareIdentity, Microsoft.PackageManagement.Pack...
+LocalPackageCheckCompleted     True
+InstalledLocalPackages
+```
+
+If you need a faster execution of the command, just skip some checks
+
+```PowerShell
+Get-PSEnvironment -SkipBackgroundCheck -SkipLocalPackageCheck
+
+Name                           Value
+----                           -----
+PSVersion                      5.1.26100.6584
+PSEdition                      Desktop
+OS                             Windows
+IsCore                         False
+Architecture                   ARM64
+CurrentRuntime                 net4.0
+Is64BitOS                      True
+Is64BitProcess                 True
+ExecutingUser                  FLOPRO11\flo
+IsElevated                     False
+RuntimePreference              win-arm64, win-arm, win-x64, win-x86
+FrameworkPreference            net48, net47, net462, net461, net45, net40, netstandard2.0, netstandard1.5, netstandard1....
+PackageManagement              1.4.8.1
+PowerShellGet                  2.2.5
+VcRedist                       @{installed=True; is64bit=True; versions=System.Collections.Hashtable}
+BackgroundCheckCompleted       False
+InstalledModules
+InstalledGlobalPackages
+LocalPackageCheckCompleted     False
+InstalledLocalPackages
+```
+
+If you have saved some nuget packages to a local folder, you can find and examine them navigating to the parent folder of the packages
+and then execute the command similar to this
+
+```PowerShell
+$ps = Get-PSEnvironment -LocalPackageFolder ".\lib"
+$ps.InstalledLocalPackages
+
+Name                           Version          Source                           ProviderName
+----                           -------          ------                           ------------
+System.Runtime.CompilerServ... 6.1.2            C:\Users\flo\Downloads\testpa... NuGet
+System.Threading.Channels      7.0.0            C:\Users\flo\Downloads\testpa... NuGet
+System.Threading.Tasks.Exte... 4.6.3            C:\Users\flo\Downloads\testpa... NuGet
+```
+
 # Contribution
 
 You are free to use this code, put in some changes and use a pull request to feedback improvements :-)


### PR DESCRIPTION
Added more switches to get faster execution of Get-PSEnvironment
Added a synopsys to Get-PSEnvironment
Changed the approach to load the versions of PowerShellGet and PackageManagement
Loading the OS directly at the start of module import to determine if PATH needs to be extended