### PR TITLE
Enhancements to get Import-Dependency and WriteLog working better together

### DIFF
--- a/.github/workflows/sqlpipeline.tests.yml
+++ b/.github/workflows/sqlpipeline.tests.yml
@@ -14,12 +14,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ windows-latest, ubuntu-latest ]
+        os: [ ubuntu-latest ]
         shell: [ pwsh ]
-        include:
-          - os: windows-latest
-            shell: powershell
-
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/sqlpipeline.tests.yml
+++ b/.github/workflows/sqlpipeline.tests.yml
@@ -14,8 +14,11 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ windows-latest ]
-        shell: [ powershell, pwsh ]
+        os: [ windows-latest, ubuntu-latest ]
+        shell: [ pwsh ]
+        include:
+          - os: windows-latest
+            shell: powershell
 
 
     runs-on: ${{ matrix.os }}

--- a/ImportDependency/ImportDependency/ImportDependency.psd1
+++ b/ImportDependency/ImportDependency/ImportDependency.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ImportDependency.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.6'
+ModuleVersion = '0.3.7'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -115,6 +115,7 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+0.3.7 Returning absolute logfile path rather than a relative one
 0.3.6 Adding a function Get-TemporaryPath to get a temporary path on Windows and Linux
       Adding two functions to get pwsh and python path
 0.3.5 Adding Linux functionality for current executing user and if it is sudo/elevated

--- a/ImportDependency/ImportDependency/Public/Import-Dependency.ps1
+++ b/ImportDependency/ImportDependency/Public/Import-Dependency.ps1
@@ -108,9 +108,10 @@ Function Import-Dependency {
         If ( $KeepLogfile -eq $false -and $null -ne $getLogfile ) {
             $currentLogfile = Get-Logfile
             $logfile = ".\dependencies_import.log"
-            Set-Logfile -Path $logfile
+            $logfileAbsolute = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($f)
+            Set-Logfile -Path $logfileAbsolute
             Write-Log -message "----------------------------------------------------" -Severity VERBOSE
-            Write-Log -Message "Changed logfile from '$( $currentLogfile.fullname )' to '$( $logfile )'"
+            Write-Log -Message "Changed logfile from '$( $currentLogfile.fullname )' to '$( $logfileAbsolute )'"
         } else {
             $logfile = ".\dependencies_import.log"
             Set-Logfile -Path $logfile

--- a/WriteLog/WriteLog/Public/Get-Logfile.ps1
+++ b/WriteLog/WriteLog/Public/Get-Logfile.ps1
@@ -20,11 +20,11 @@ Function Get-Logfile {
         If ( ( Test-Path -Path $logfile -IsValid ) -eq $false ) {
             Write-Error -Message "Invalid variable '`$logfile'. The path '$( $logfile )' is invalid."
         } else {
-            $item = Get-Item -Path $logfile
+            $item = $logfile
         }
 
     }
 
-    $item
+    return $item
 
 }

--- a/WriteLog/WriteLog/Public/Set-Logfile.ps1
+++ b/WriteLog/WriteLog/Public/Set-Logfile.ps1
@@ -42,6 +42,8 @@ Function Set-Logfile {
         # Return
         Write-Verbose "Using the file: $( $Script:logfile )"
 
+        $True
+
     }
 
 }

--- a/WriteLog/WriteLog/WriteLog.psd1
+++ b/WriteLog/WriteLog/WriteLog.psd1
@@ -5,7 +5,7 @@
 RootModule = 'WriteLog.psm1'
 
 # Die Versionsnummer dieses Moduls
-ModuleVersion = '0.9.16'
+ModuleVersion = '0.9.17'
 
 # Unterstützte PSEditions
 # CompatiblePSEditions = @()
@@ -132,6 +132,7 @@ PrivateData = @{
 
         # 'ReleaseNotes' des Moduls
         ReleaseNotes = '
+0.9.17 Fixing the return of a path rather than a file object in Get-Logfile
 0.9.16 Adding support for temporary path in Linux
 0.9.15 Fixing linux compatibility when importing the module
 0.9.14 If message is null, it will throw an error. Invalid path for logfile will throw an error, too


### PR DESCRIPTION
Fixing the return of a path rather than a file object in Get-Logfile and putting WriteLog to 0.9.17
Also fixing Import-Dependency to output logfile with absolute path
And only testing on Ubuntu for SqlPipeline