### PR TITLE
Fixing two bugs in ImportDependency and bump to 0.4.10

### DIFF
--- a/ImportDependency/ImportDependency/ImportDependency.psd1
+++ b/ImportDependency/ImportDependency/ImportDependency.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ImportDependency.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.9'
+ModuleVersion = '0.4.10'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -118,6 +118,8 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+0.4.10 Fixed a problem when getting the python path on Windows
+       Fixed a problem with powershell core where a path was tried to be loaded, even when pscore is not installed
 0.4.9 Added a check to remove inaccessible paths from PSModulePath to avoid errors when loading modules
 0.4.8 Added all executionpolicies to Get-PSEnvironment
       Fixed a problem with checking elevation on Linux and MacOS

--- a/ImportDependency/ImportDependency/ImportDependency.psm1
+++ b/ImportDependency/ImportDependency/ImportDependency.psm1
@@ -222,8 +222,8 @@ Write-Verbose "Checking more details about PS Core"
 
 # Check if pscore is installed
 $pwshCommand = Get-Command -commandType Application -Name "pwsh*"
-$Script:defaultPsCoreVersion = $pwshCommand[0].Version
 If ( $pwshCommand.Count -gt 0 ) {
+    $Script:defaultPsCoreVersion = $pwshCommand[0].Version
     $Script:isCoreInstalled = $true
     if ($Script:os -eq "Windows") {
         # For Windows

--- a/ImportDependency/ImportDependency/Public/Get-PythonPath.ps1
+++ b/ImportDependency/ImportDependency/Public/Get-PythonPath.ps1
@@ -1,25 +1,68 @@
 function Get-PythonPath {
 
     $pse = Get-PSEnvironment -SkipBackgroundCheck -SkipLocalPackageCheck
-    
-    $pythonPath = $null
+
+    $pythonPaths = @()
     if ($pse.OS -eq "Windows") {
         # For Windows
-        $pythonPath = (Get-Command python).Source
+        $pythonPaths = @( ( Get-Command -CommandType Application -Name "python*" -ErrorAction SilentlyContinue ).Source | Where-Object { $_ -notlike "*pythonw.exe" } )
     } elseif ( $pse.OS -eq "Linux" ) {
         # For Linux
-        If ( $null -ne (which python) ) {
-            $pythonPath = (which python)
-        } elseif ( $null -ne (which python3) ) {
-            $pythonPath = (which python3)
+        @("python3", "python") | ForEach-Object {
+            try {
+                $cmd = (which $_ 2>$null)
+                if (-not [string]::IsNullOrEmpty($cmd)) {
+                    $pythonPaths += $cmd
+                }
+            } catch {
+                # Command not found
+            }
         }
+        $pythonPaths = @( $pythonPaths | Select-Object -Unique )
     }
 
-    if (-not $pythonPath) {
+    if ($pythonPaths.Count -eq 0) {
         Write-Verbose "Python is not installed or not found."
-    } else {
-        Write-Verbose "Python Path: $pythonPath"
+        return $null
     }
+
+    if ($pythonPaths.Count -gt 1) {
+        Write-Verbose "Multiple Python installations found: $($pythonPaths -join ', ')"
+    }
+
+    # Resolve version for each candidate
+    $pythonWithVersion = @(
+        $pythonPaths | ForEach-Object {
+            $path = $_
+            try {
+                $versionOutput = & $path --version 2>&1
+                if ($versionOutput -match "Python\s+(\d+(?:\.\d+)+)") {
+                    [PSCustomObject]@{
+                        Path    = $path
+                        Version = [System.Version]$Matches[1]
+                    }
+                }
+            } catch {
+                # Skip paths that cannot be executed
+            }
+        } | Where-Object { $null -ne $_ }
+    )
+
+    if ($pythonWithVersion.Count -eq 0) {
+        Write-Verbose "Python is not installed or not found."
+        return $null
+    }
+
+    $highestVersion = ( $pythonWithVersion | Sort-Object -Property Version -Descending | Select-Object -First 1 ).Version
+    $highestVersionPaths = @( $pythonWithVersion | Where-Object { $_.Version -eq $highestVersion } )
+
+    if ($highestVersionPaths.Count -gt 1) {
+        Write-Verbose "Multiple Python installations share the same highest version ($highestVersion): $($highestVersionPaths.Path -join ', '). Using the first one."
+    }
+
+    $pythonPath = $highestVersionPaths[0].Path
+
+    Write-Verbose "Python Path: $pythonPath (Version: $highestVersion)"
 
     return $pythonPath
 


### PR DESCRIPTION
- Fixed a problem when getting the python path on Windows
- Fixed a problem with powershell core where a path was tried to be loaded, even when pscore is not installed