### PR TITLE
Bumping ImportDependency to 0.4.20 to fix architecture handling

### DIFF
--- a/ImportDependency/ImportDependency/ImportDependency.psd1
+++ b/ImportDependency/ImportDependency/ImportDependency.psd1
@@ -5,7 +5,7 @@
 RootModule = 'ImportDependency.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.19'
+ModuleVersion = '0.4.20'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -118,6 +118,19 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+0.4.20 Fixed the real root cause behind 0.4.18/0.4.19: on a genuinely ARM64 Windows machine, both
+       RuntimeInformation.ProcessArchitecture AND the Get-CimInstance Win32_OperatingSystem fallback
+       can come back empty/blocked at once (confirmed in Windows Sandbox''s locked-down WDAGUtilityAccount
+       context -- the exact same PowerShell build reports ARM64 correctly outside the sandbox on the same
+       hardware). The remaining fallback, Is64BitOperatingSystem, only distinguishes 32-bit vs 64-bit and
+       cannot tell ARM64 from x64, so it normalized to a generic "64-bit" that got misclassified as "x64" --
+       causing DuckDB''s native loader to pick the wrong (win-x64 instead of win-arm64) runtime folder and
+       fail with ERROR_BAD_EXE_FORMAT (193), despite loading a perfectly valid x64 binary; it was simply the
+       wrong architecture for the real CPU. That final fallback now checks the PROCESSOR_ARCHITECTURE
+       environment variable first (confirmed still available and correct in that same sandbox) before
+       falling back further to the bitness-only check. 0.4.18/0.4.19''s LoadLibrary retry logic remains in
+       place as a genuine improvement (no more silently swallowed native-load failures) but was not the fix
+       for this specific problem
 0.4.19 Widened 0.4.18''s kernel32 LoadLibrary retry from 3 fixed 500ms attempts (~2s total) to 10 attempts
        with exponential backoff capped at 3s (~18s worst case). Confirmed in a clean Windows Sandbox that
        3 retries was still too short for Windows Defender''s real-time scan of a freshly-extracted native

--- a/ImportDependency/ImportDependency/ImportDependency.psm1
+++ b/ImportDependency/ImportDependency/ImportDependency.psm1
@@ -273,10 +273,25 @@ If ( $null -ne [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchi
 
     } catch {
 
-        # CIM/WMI can be blocked in locked-down environments (e.g. Windows Sandbox's WDAGUtilityAccount),
-        # so fall back to a check that does not need WMI access
-        Write-Verbose "Could not query Win32_OperatingSystem via CIM, falling back to Is64BitOperatingSystem: $( $_.Exception.Message )"
-        $arch = If ( [System.Environment]::Is64BitOperatingSystem ) { "64-bit" } else { "32-bit" }
+        # CIM/WMI can be blocked in locked-down environments (e.g. Windows Sandbox's WDAGUtilityAccount).
+        # Confirmed in exactly that environment: RuntimeInformation.ProcessArchitecture (the primary check
+        # above) came back empty there too, on an otherwise perfectly ordinary ARM64 machine (works fine
+        # outside the sandbox on the same hardware/PS build) -- so both of the first two checks can fail
+        # at once on a real ARM64 box. Is64BitOperatingSystem alone only distinguishes 32-bit vs 64-bit; it
+        # cannot tell ARM64 from x64, so it used to normalize to a generic "64-bit" that got misclassified
+        # as "x64" further down -- causing DuckDB's native loader to pick the wrong (win-x64 instead of
+        # win-arm64) runtime folder entirely, and fail with ERROR_BAD_EXE_FORMAT despite a perfectly valid
+        # x64 binary being loaded (it was just the wrong architecture for the real CPU). PROCESSOR_ARCHITECTURE
+        # is set directly by the OS and was confirmed to still be available and correct in that same
+        # locked-down sandbox, so check it before falling back further.
+        Write-Verbose "Could not query Win32_OperatingSystem via CIM: $( $_.Exception.Message )"
+        If ( -not [String]::IsNullOrEmpty( $env:PROCESSOR_ARCHITECTURE ) ) {
+            Write-Verbose "Falling back to the PROCESSOR_ARCHITECTURE environment variable"
+            $arch = $env:PROCESSOR_ARCHITECTURE
+        } else {
+            Write-Verbose "Falling back to Is64BitOperatingSystem"
+            $arch = If ( [System.Environment]::Is64BitOperatingSystem ) { "64-bit" } else { "32-bit" }
+        }
 
     }
 


### PR DESCRIPTION
Especially for sandbox environments where [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq $null