### PR TITLE
Bumping InstallDependency to 0.3.12

### DIFF
--- a/InstallDependency/InstallDependency/InstallDependency.psd1
+++ b/InstallDependency/InstallDependency/InstallDependency.psd1
@@ -5,7 +5,7 @@
 RootModule = 'InstallDependency.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.11'
+ModuleVersion = '0.3.12'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -113,6 +113,10 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '
+0.3.12 Re-import PackageManagement/PowerShellGet in-session right after updating them, since Import-Module -Force
+       merely stacks the new version alongside the old one still loaded in-process and cmdlets kept resolving
+       to the stale binaries until the whole PowerShell session was restarted.
+       Fix with -AllowClobber when installing local packages
 0.3.11 Added a pinned version support to keep the same version of a package installed for all environments.
        This is needed for DuckDB.NET to keep the same version for Windows PowerShell 5.1 (netstandard2.0)
        and PowerShell Core (Windows and Linux)

--- a/InstallDependency/InstallDependency/Public/Install-Dependency.ps1
+++ b/InstallDependency/InstallDependency/Public/Install-Dependency.ps1
@@ -208,7 +208,14 @@ Function Install-Dependency {
         If ( $psEnv.PackageManagement -eq "1.0.0.1" -or [String]::IsNullOrEmpty( $psEnv.PackageManagement ) ) {
             Write-Log "PackageManagement is outdated with v$( $psEnv.PackageManagement ). This is updating it now." -Severity WARNING
             try {
-                Install-Package -Name PackageManagement -ProviderName $powerShellSourceProviderName -Force | Out-Null
+                Install-Package -Name PackageManagement -ProviderName $powerShellSourceProviderName -Force -AllowClobber | Out-Null
+                # The installed binaries won't be used until re-imported: 'Import-Module -Force' merely stacks
+                # the new version alongside the old one still loaded in this process, and cmdlets keep resolving
+                # to the old module. Removing first, then a bare re-import (auto-picks the newest available
+                # version), is what actually swaps the active binaries in-session.
+                Remove-Module -Name PackageManagement -Force -ErrorAction SilentlyContinue
+                Import-Module -Name PackageManagement -ErrorAction Stop
+                Write-Log "PackageManagement re-imported as v$( (Get-Module PackageManagement).Version )" -Severity VERBOSE
             } catch {
                 Write-Log "Could not update PackageManagement: $( $_.Exception.Message )" -Severity WARNING
             }
@@ -218,7 +225,11 @@ Function Install-Dependency {
         If ( $psEnv.PowerShellGet -eq "1.0.0.1" -or [String]::IsNullOrEmpty( $psEnv.PowerShellGet ) ) {
             Write-Log "PowerShellGet is outdated with v$( $psEnv.PowerShellGet ). This is updating it now." -Severity WARNING
             try {
-                Install-Package -Name PowerShellGet -ProviderName $powerShellSourceProviderName -Force | Out-Null
+                Install-Package -Name PowerShellGet -ProviderName $powerShellSourceProviderName -Force -AllowClobber | Out-Null
+                # Same in-session reload issue as PackageManagement above.
+                Remove-Module -Name PowerShellGet -Force -ErrorAction SilentlyContinue
+                Import-Module -Name PowerShellGet -ErrorAction Stop
+                Write-Log "PowerShellGet re-imported as v$( (Get-Module PowerShellGet).Version )" -Severity VERBOSE
             } catch {
                 Write-Log "Could not update PowerShellGet: $( $_.Exception.Message )" -Severity WARNING
             }


### PR DESCRIPTION
Re-import PackageManagement/PowerShellGet in-session right after updating them, since Import-Module -Force merely stacks the new version alongside the old one still loaded in process and cmdlets kept resolving to the stale binaries until the whole PowerShell session was restarted.

Fix with -AllowClobber when installing local packages